### PR TITLE
async support for mad-migration

### DIFF
--- a/madmigration/db_init/async_connection_engine.py
+++ b/madmigration/db_init/async_connection_engine.py
@@ -1,0 +1,35 @@
+from sqlalchemy import event, Table
+from sqlalchemy.ext.automap import automap_base
+
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sqlalchemy_utils.functions.database import database_exists
+
+from madmigration.db_init.connection_engine import DestinationDB
+from madmigration.utils.helpers import database_not_exists, goodby_message
+
+
+@event.listens_for(Table, "after_parent_attach")
+def before_parent_attach(target):
+    if not target.primary_key and "id" in target.c:
+        print(target)
+
+
+class AsyncSourceDB:
+    def __init__(self, source_uri):
+        if not database_exists(source_uri):
+            goodby_message(database_not_exists(source_uri), 0)
+        self.base = automap_base()
+        self.engine = create_async_engine(source_uri, echo=False)
+        self.base.prepare(self.engine, reflect=True)
+        self.session = AsyncSession(self.engine, autocommit=False, autoflush=False)
+
+
+class AsyncDestinationDB(DestinationDB):
+    def __init__(self, destination_uri):
+        super().__init__(destination_uri)
+
+        self.base = automap_base()
+        self.engine = create_async_engine(destination_uri)
+        self.session = AsyncSession(self.engine, autocommit=False, autoflush=False)

--- a/madmigration/db_init/async_connection_engine.py
+++ b/madmigration/db_init/async_connection_engine.py
@@ -1,35 +1,42 @@
+import asyncio
+
+import gino
 from sqlalchemy import event, Table
 from sqlalchemy.ext.automap import automap_base
-
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from sqlalchemy_utils.functions.database import database_exists
+from sqlalchemy import create_engine
 
 from madmigration.db_init.connection_engine import DestinationDB
-from madmigration.utils.helpers import database_not_exists, goodby_message
+from madmigration.utils.helpers import (
+    database_not_exists,
+    goodby_message,
+    aio_database_exists,
+    run_await_funtion
+)
 
 
 @event.listens_for(Table, "after_parent_attach")
-def before_parent_attach(target):
+def before_parent_attach(target, parent):
     if not target.primary_key and "id" in target.c:
         print(target)
 
 
 class AsyncSourceDB:
     def __init__(self, source_uri):
-        if not database_exists(source_uri):
+        if not aio_database_exists(source_uri):
             goodby_message(database_not_exists(source_uri), 0)
-        self.base = automap_base()
-        self.engine = create_async_engine(source_uri, echo=False)
-        self.base.prepare(self.engine, reflect=True)
-        self.session = AsyncSession(self.engine, autocommit=False, autoflush=False)
+
+        metadata = gino.Gino()
+        self.base = automap_base(metadata=metadata)
+        self.engine = create_engine(source_uri)
+        self.base.prepare()
 
 
 class AsyncDestinationDB(DestinationDB):
     def __init__(self, destination_uri):
-        super().__init__(destination_uri)
+        self.check_for_or_create_database(destination_uri, check_for_database=aio_database_exists)
+        self.engine = create_engine(destination_uri, strategy='gino')
 
-        self.base = automap_base()
-        self.engine = create_async_engine(destination_uri)
-        self.session = AsyncSession(self.engine, autocommit=False, autoflush=False)
+
+@run_await_funtion()
+async def create_engine(*args, **kwargs):
+    return await gino.create_engine(*args, **kwargs)

--- a/madmigration/db_init/connection_engine.py
+++ b/madmigration/db_init/connection_engine.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy_utils.functions.database import database_exists, create_database
 import sys
-from madmigration.utils.helpers import issue_url,app_name,parse_uri
+from madmigration.utils.helpers import issue_url, app_name, parse_uri
 from madmigration.utils.helpers import database_not_exists, goodby_message
 import logging
 logger = logging.getLogger(__name__)
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 def before_parent_attach(target, parent):
     if not target.primary_key and "id" in target.c:
         print(target)
-
 
 
 class SourceDB:
@@ -41,13 +40,11 @@ class DestinationDB:
                         goodby_message(database_not_exists(destination_uri), 1)
                     break
                 elif msg.lower() == "n":
-                    goodby_message("Destination database does not exit \nExiting ..", 0)
+                    goodby_message("Destination database does not exist \nExiting ...", 0)
                     break
                 print("Please, select command")
 
-        
         self.base = automap_base()
         self.engine = create_engine(destination_uri)
         # self.base.prepare(self.engine, reflect=True)
         self.session = Session(self.engine, autocommit=False, autoflush=False)
-

--- a/madmigration/db_init/connection_engine.py
+++ b/madmigration/db_init/connection_engine.py
@@ -27,7 +27,15 @@ class SourceDB:
 
 class DestinationDB:
     def __init__(self, destination_uri):
-        if not database_exists(destination_uri):
+        self.check_for_or_create_database(destination_uri)
+
+        self.base = automap_base()
+        self.engine = create_engine(destination_uri)
+        # self.base.prepare(self.engine, reflect=True)
+        self.session = Session(self.engine, autocommit=False, autoflush=False)
+
+    def check_for_or_create_database(self, destination_uri, check_for_database: callable = database_exists):
+        if not check_for_database(destination_uri):
             while True:
                 database = parse_uri(destination_uri)
                 msg = input(f"The database {database} does not exists, would you like to create it in the destination?(y/n) ")
@@ -43,8 +51,3 @@ class DestinationDB:
                     goodby_message("Destination database does not exist \nExiting ...", 0)
                     break
                 print("Please, select command")
-
-        self.base = automap_base()
-        self.engine = create_engine(destination_uri)
-        # self.base.prepare(self.engine, reflect=True)
-        self.session = Session(self.engine, autocommit=False, autoflush=False)

--- a/madmigration/db_operations/async_operations.py
+++ b/madmigration/db_operations/async_operations.py
@@ -1,0 +1,169 @@
+import asyncio
+import logging
+
+from sqlalchemy.schema import DropConstraint, DropTable
+from sqlalchemy import MetaData, ForeignKeyConstraint, Table
+from sqlalchemy.engine import reflection
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncDbOperations:
+    def __init__(self, engine):
+        self.engine = engine
+        self.metadata = MetaData()
+        self.loop = asyncio.get_event_loop()
+
+    async def drop_table(self, table_name):
+        """ Drop table with given name """
+        try:
+            conn = await self.engine.connect()
+
+            # context config for alembic
+            ctx = MigrationContext.configure(conn)
+            op = Operations(ctx)
+            op.drop_table(table_name)
+
+            logger.info("Table %s dropped", table_name)
+            return True
+        except Exception as err:
+            logger.error("drop_tables [error] -> %s", err)
+            return False
+        finally:
+            logger.info("Session closed")
+            await conn.close()
+
+    async def bulk_drop_tables(self, *table_name):
+        """ Drop tables with given name """
+        try:
+            await asyncio.gather(*[self.drop_table(table) for table in table_name])
+            return True
+        except Exception as err:
+            logger.error("bulk_drop_tables [error] -> %s", err)
+
+    async def create_table(self, table_name: str, *columns) -> bool:
+        """ create prepared table with alembic """
+        try:
+            table = Table(table_name, self.metadata, *columns)
+            table.create(self.engine, checkfirst=True)
+
+            logger.info("%s is created", table_name)
+            return True
+        except Exception as err:
+            logger.error("_create_table [error] -> %s", err)
+            return False
+
+    async def add_column(self, table_name: str, *column) -> bool:
+        """ Add column to given table """
+        try:
+            conn = await self.engine.connect()
+            ctx = MigrationContext.configure(conn)
+            op = Operations(ctx)
+
+            # run blocking function cooncurrently in an async executor
+            col_list = [
+                self.loop.run_in_executor(None, op.add_column, table_name, col) for col in column
+            ]
+            await asyncio.gather(*col_list)
+
+            return True
+        except Exception as err:
+            logger.error("add_column [error] -> %s", err)
+            return False
+        finally:
+            await conn.close()
+
+    async def create_fk_constraint(self, fk_constraints: list, const_columns: dict) -> bool:
+        """ Get list of foreign keys from static list `fk_constraints` and created it  """
+        try:
+            conn = await self.engine.connect()
+
+            ctx = MigrationContext.configure(conn)
+            op = Operations(ctx)
+            for constraint in fk_constraints:
+                dest_table_name = constraint.pop("table_name")
+                column_name = constraint.pop("column_name")
+                source_table = constraint.pop("source_table")
+                dest_column = constraint.pop("dest_column")
+
+                if dest_column not in const_columns[source_table]:
+                    op.create_foreign_key(
+                        None,
+                        source_table,
+                        dest_table_name,
+                        [dest_column],
+                        [column_name],
+                        **constraint,
+                    )
+            return True
+
+        except Exception as err:
+            logger.error("create_fk_constraint [error] -> %s", err)
+            return False
+
+        finally:
+            await conn.close()
+
+    async def drop_fk(self, fk_constraints: str):
+        try:
+            conn = await self.engine.connect()
+            transactional = await conn.begin()
+
+            await asyncio.gather(
+                *[conn.execute(
+                    DropConstraint(fk, cascade=True)
+                ) for fk in fk_constraints]
+            )
+
+            await transactional.commit()
+            return True
+        except Exception as err:
+            logger.error("fk_drop [error] -> %s", err)
+            return False
+        finally:
+            await conn.close()
+
+    async def db_drop_everything(self, table_list):
+        """ From http://www.sqlalchemy.org/trac/wiki/UsageRecipes/DropEverything """
+        try:
+            logger.warning("SIGNAL DROP -> %s", table_list)
+            conn = await self.engine.connect()
+            transactional = await conn.begin()
+            inspector = reflection.Inspector.from_engine(self.engine)
+
+            tables = []
+            all_foreign_keys = []
+
+            for table_name in inspector.get_table_names():
+                if table_name in table_list:
+
+                    fks = map(lambda fk: ForeignKeyConstraint((), (), name=fk["name"]) if fk["name"],
+                              inspector.get_foreign_keys(table_name))
+                    fks = list(fks)
+
+                    t = Table(table_name, self.metadata, *fks)
+                    tables.append(t)
+                    all_foreign_keys.extend(fks)
+
+            await asyncio.gather(
+                *[conn.execute(
+                    DropConstraint(foreignkey)
+                ) for foreignkey in all_foreign_keys]
+            )
+
+            await asyncio.gather(
+                *[conn.execute(
+                    DropTable(table)
+                ) for table in tables]
+            )
+
+            await transactional.commit()
+            return True
+        except Exception as err:
+            logger.error("db_drop_everything [error] -> %s", err)
+            return False
+        finally:
+            await conn.close()

--- a/madmigration/db_operations/async_operations.py
+++ b/madmigration/db_operations/async_operations.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 
-from sqlalchemy.schema import DropConstraint, DropTable
-from sqlalchemy import MetaData, ForeignKeyConstraint, Table
+import gino
+
+from gino.schema import DropConstraint, DropTable
+from sqlalchemy import ForeignKeyConstraint, Table
 from sqlalchemy.engine import reflection
 
 from alembic.migration import MigrationContext
@@ -14,156 +16,20 @@ logger = logging.getLogger(__name__)
 class AsyncDbOperations:
     def __init__(self, engine):
         self.engine = engine
-        self.metadata = MetaData()
+        self.metadata = gino.Gino()
         self.loop = asyncio.get_event_loop()
 
-    async def drop_table(self, table_name):
-        """ Drop table with given name """
-        try:
-            conn = await self.engine.connect()
-
-            # context config for alembic
-            ctx = MigrationContext.configure(conn)
-            op = Operations(ctx)
-            op.drop_table(table_name)
-
-            logger.info("Table %s dropped", table_name)
-            return True
-        except Exception as err:
-            logger.error("drop_tables [error] -> %s", err)
-            return False
-        finally:
-            logger.info("Session closed")
-            await conn.close()
-
-    async def bulk_drop_tables(self, *table_name):
-        """ Drop tables with given name """
-        try:
-            await asyncio.gather(*[self.drop_table(table) for table in table_name])
-            return True
-        except Exception as err:
-            logger.error("bulk_drop_tables [error] -> %s", err)
-
     async def create_table(self, table_name: str, *columns) -> bool:
-        """ create prepared table with alembic """
+        """ create a new table """
         try:
             table = Table(table_name, self.metadata, *columns)
-            table.create(self.engine, checkfirst=True)
+
+            # the gino object comes from "metadata" included in the Table class. metadata is
+            # a gino.Gino object which is why table.gino is possible
+            await table.gino.create(self.engine, checkfirst=True)
 
             logger.info("%s is created", table_name)
             return True
         except Exception as err:
             logger.error("_create_table [error] -> %s", err)
             return False
-
-    async def add_column(self, table_name: str, *column) -> bool:
-        """ Add column to given table """
-        try:
-            conn = await self.engine.connect()
-            ctx = MigrationContext.configure(conn)
-            op = Operations(ctx)
-
-            # run blocking function cooncurrently in an async executor
-            col_list = [
-                self.loop.run_in_executor(None, op.add_column, table_name, col) for col in column
-            ]
-            await asyncio.gather(*col_list)
-
-            return True
-        except Exception as err:
-            logger.error("add_column [error] -> %s", err)
-            return False
-        finally:
-            await conn.close()
-
-    async def create_fk_constraint(self, fk_constraints: list, const_columns: dict) -> bool:
-        """ Get list of foreign keys from static list `fk_constraints` and created it  """
-        try:
-            conn = await self.engine.connect()
-
-            ctx = MigrationContext.configure(conn)
-            op = Operations(ctx)
-            for constraint in fk_constraints:
-                dest_table_name = constraint.pop("table_name")
-                column_name = constraint.pop("column_name")
-                source_table = constraint.pop("source_table")
-                dest_column = constraint.pop("dest_column")
-
-                if dest_column not in const_columns[source_table]:
-                    op.create_foreign_key(
-                        None,
-                        source_table,
-                        dest_table_name,
-                        [dest_column],
-                        [column_name],
-                        **constraint,
-                    )
-            return True
-
-        except Exception as err:
-            logger.error("create_fk_constraint [error] -> %s", err)
-            return False
-
-        finally:
-            await conn.close()
-
-    async def drop_fk(self, fk_constraints: str):
-        try:
-            conn = await self.engine.connect()
-            transactional = await conn.begin()
-
-            await asyncio.gather(
-                *[conn.execute(
-                    DropConstraint(fk, cascade=True)
-                ) for fk in fk_constraints]
-            )
-
-            await transactional.commit()
-            return True
-        except Exception as err:
-            logger.error("fk_drop [error] -> %s", err)
-            return False
-        finally:
-            await conn.close()
-
-    async def db_drop_everything(self, table_list):
-        """ From http://www.sqlalchemy.org/trac/wiki/UsageRecipes/DropEverything """
-        try:
-            logger.warning("SIGNAL DROP -> %s", table_list)
-            conn = await self.engine.connect()
-            transactional = await conn.begin()
-            inspector = reflection.Inspector.from_engine(self.engine)
-
-            tables = []
-            all_foreign_keys = []
-
-            for table_name in inspector.get_table_names():
-                if table_name in table_list:
-
-                    fks = map(lambda fk: ForeignKeyConstraint((), (), name=fk["name"]) if fk["name"],
-                              inspector.get_foreign_keys(table_name))
-                    fks = list(fks)
-
-                    t = Table(table_name, self.metadata, *fks)
-                    tables.append(t)
-                    all_foreign_keys.extend(fks)
-
-            await asyncio.gather(
-                *[conn.execute(
-                    DropConstraint(foreignkey)
-                ) for foreignkey in all_foreign_keys]
-            )
-
-            await asyncio.gather(
-                *[conn.execute(
-                    DropTable(table)
-                ) for table in tables]
-            )
-
-            await transactional.commit()
-            return True
-        except Exception as err:
-            logger.error("db_drop_everything [error] -> %s", err)
-            return False
-        finally:
-            await conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,17 @@
 alembic==1.4.2
 appdirs==1.4.4
 astroid==2.4.2
+asyncpg==0.21.0
 attrs==19.3.0
 black==19.10b0
 click==7.1.2
+contextvars==2.4
 dataclasses==0.8
 flake8==3.8.3
 future==0.18.2
+gino==1.0.1
 greenlet==1.0a1
+immutables==0.14
 importlib-metadata==1.7.0
 isort==4.3.21
 Jinja2==2.11.2
@@ -38,7 +42,7 @@ python-editor==1.0.4
 PyYAML==5.3.1
 regex==2020.7.14
 six==1.15.0
-SQLAlchemy==1.4.0b1
+SQLAlchemy==1.3.22
 SQLAlchemy-Utils==0.36.8
 toml==0.10.1
 tornado==6.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@ astroid==2.4.2
 attrs==19.3.0
 black==19.10b0
 click==7.1.2
+dataclasses==0.8
 flake8==3.8.3
 future==0.18.2
+greenlet==1.0a1
 importlib-metadata==1.7.0
 isort==4.3.21
 Jinja2==2.11.2
@@ -36,7 +38,7 @@ python-editor==1.0.4
 PyYAML==5.3.1
 regex==2020.7.14
 six==1.15.0
-SQLAlchemy==1.3.18
+SQLAlchemy==1.4.0b1
 SQLAlchemy-Utils==0.36.8
 toml==0.10.1
 tornado==6.0.4


### PR DESCRIPTION
This was rather tricky and I had to result to using gino because sqlalchemy 1.4 breaks the utility functions.
The driver itself is ready and works exactly the same as the non-async does.

This was tested majorly with asyncpg, but I am fairly certain it would also work for aiomysql and similar async drivers
```python
source1 = AsyncSourceDB("postgresql+asyncpg://postgres:hi12@localhost/test_db")
destination = AsyncDestinationDB("postgresql+asyncpg://postgres:hi12@localhost/tested_db")
```

This also comes with the very basics for async database operations even though for the time being only _create_table_ is present. 
The reason being that was a [bug](https://github.com/python-gino/gino/issues/751) or perhaps a missing feature(fairly certain it is a bug) which I discovered in gino and I have raised an issue. I might raise a PR later if I get some time on my hands that way I can fix that and finish this.